### PR TITLE
Add key bindings and change command name

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "PyDoc",
     "description": "Generates the docstring for functions and classes",
     "icon": "assets/code-comments.jpg",
-    "version": "0.3.3"  ,
+    "version": "0.4.0",
     "publisher": "reddevil",
     "engines": {
         "vscode": "^1.25.0"
@@ -26,9 +26,22 @@
         "commands": [
             {
                 "command": "extension.docstring",
-                "title": "Docstring"
+                "title": "PyDoc: Generate function docstring"
             }
-        ]
+        ],
+        "keybindings": [
+            {
+                "command": "extension.docstring",
+                "key": "ctrl+alt+b"
+            }
+		],
+		"menus": {
+			"editor/context": [
+				{
+					"command": "extension.docstring"
+				}
+			]
+		}
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
# Add key bindings and change command name

- Keybinding (`ctrl+alt+b`): It was hard to find a comfortable combination
that was not being used by VSCode itself. This one seems ok for me.

- Command name: I changed it to reflect the Extension name (`PyDoc`) and to
give a brief description about what the extension does.

- Also changed the version number for a `minor revision` as a
feature was added.

# Closes
#3 