### PR TITLE
Add description field for returned value of a function.

### DIFF
--- a/src/generateDocString.ts
+++ b/src/generateDocString.ts
@@ -44,15 +44,16 @@ export class Docstring {
         const endQuotes = '\t"""';
         const exceptions = '\t:raises:\n\n';
         const rType = '\t:rtype:\n';
+        const rDescription = '\t:returns:\n';
         let linePosition = this.editor.selection.active.line;
 
         if (params && isArray(params)) {
             const paramStr = this.generateParamDocstring(params);
-            const finalStr = startQuotes + paramStr + exceptions + rType + endQuotes;
+            const finalStr = startQuotes + paramStr + exceptions + rType + rDescription + endQuotes;
             this.editor.insertSnippet(snippet.appendText(finalStr), new vscode.Position(linePosition + 1, 4))
         }
         else {
-            const finalStr = startQuotes + exceptions + rType + endQuotes;
+            const finalStr = startQuotes + exceptions + rType + rDescription + endQuotes;
             this.editor.insertSnippet(snippet.appendText(finalStr), new vscode.Position(linePosition + 1, 4))
         }
     }


### PR DESCRIPTION
Based on differents `docstring` specifications (that actually implement a `description` for a `return value`) and to avoid confusion with the `function description`, I have chosen using the term `:returns:` after `:rtype:` as a field for the description of the returned value. 